### PR TITLE
fix: handle non existant registered users

### DIFF
--- a/src/commands/findMembersAt.ts
+++ b/src/commands/findMembersAt.ts
@@ -1,7 +1,6 @@
 import { Middleware } from 'telegraf';
 import { markdown } from 'telegram-format';
 import { BotContext } from '../context';
-import { createMemberMention } from '../member';
 import {
   getCountryCodeForText,
   getCountryNameForCountryCode,
@@ -32,14 +31,7 @@ export const cmdFindMembersAt: Middleware<BotContext> = async (
     );
   }
 
-  const memberIds = ctx.database.getMembersAt(countryCode);
-  const members = await Promise.all(
-    memberIds.map(async (userId) => {
-      const member = await ctx.getChatMember(userId);
-      return createMemberMention(member.user, true);
-    })
-  );
-
+  const members = await ctx.fetchMembersMentionList(countryCode);
   const hasNoMembers = members.length === 0;
 
   const message = hasNoMembers

--- a/src/commands/pingMembersAt.ts
+++ b/src/commands/pingMembersAt.ts
@@ -1,7 +1,6 @@
 import { Middleware } from 'telegraf';
 import { markdown } from 'telegram-format';
 import { BotContext } from '../context';
-import { createMemberMention } from '../member';
 import {
   getCountryCodeForText,
   getCountryNameForCountryCode,
@@ -32,14 +31,7 @@ export const cmdPingMemberAt: Middleware<BotContext> = async (
     );
   }
 
-  const memberIds = ctx.database.getMembersAt(countryCode);
-  const members = await Promise.all(
-    memberIds.map(async (userId) => {
-      const member = await ctx.getChatMember(userId);
-      return createMemberMention(member.user);
-    })
-  );
-
+  const members = await ctx.fetchMembersMentionList(countryCode);
   const hasNoMembers = members.length === 0;
 
   const message = hasNoMembers

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
+import { Alpha2Code } from 'i18n-iso-countries';
 import pino from 'pino';
 import { Context } from 'telegraf';
 import TelegrafI18n from 'telegraf-i18n';
@@ -13,6 +14,9 @@ export interface BotContext extends Context {
   config: Config;
   database: DatabaseInstance;
   loadDatabase: () => Promise<DatabaseInstance>;
+  fetchMembersMentionList: (
+    countryCode: Alpha2Code
+  ) => Promise<string[]>;
   replyWithAutoDestructiveMessage: (
     markdownMessage: string,
     options?: AutoDestructiveMessageOptions

--- a/src/extensions/promises.ts
+++ b/src/extensions/promises.ts
@@ -1,0 +1,26 @@
+/**
+ * Filters a list of PromiesSettledResult<T> into a PromiseFulfilledResult<T>
+ * and casts it so it's correctly type checked for consumers.
+ **/
+export const withFulfilled = <T>(
+  promises: PromiseSettledResult<T>[]
+) => {
+  return promises.filter(
+    (promise) => promise.status === 'fulfilled'
+  ) as PromiseFulfilledResult<T>[];
+};
+
+/**
+ * Filters a list of PromiesSettledResult<T> into a PromiseRejectedResult
+ * and casts it so it's correctly type checked for consumers.
+ *
+ * Unfortunately, `rejection.reason` is any due to typescript inability
+ * to enforce an error interface on Promise rejections.
+ **/
+export const withRejected = <T>(
+  promises: PromiseSettledResult<T>[]
+) => {
+  return promises.filter(
+    (promise) => promise.status === 'rejected'
+  ) as PromiseRejectedResult[];
+};


### PR DESCRIPTION
This PR introduces a new abstraction to build the mentions message that handles registered users that don't exist anymore. This ignores those when building the replies and triggers non-blocking calls to unregister those as well.

Fixes #5 