### PR TITLE
Feature/add remote location

### DIFF
--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -15,3 +15,4 @@ listing:
   noMembers: "${mention} There are no members registered."
 remote:
   remoteMemberRegistered: "${mention} You registered as remote from ${countryFrom} to ${countryTo}. You'll receive a notification when someone pings remote members for these two countries."
+  memberDeregisteredFromLocation: "${mention} You deregistered yourself as remote."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -13,3 +13,5 @@ errors:
   failedToFetchContent: "${mention} Failed to find the content you're looking for."
 listing:
   noMembers: "${mention} There are no members registered."
+remote:
+  remoteMemberRegistered: "${mention} You registered as remote from ${countryFrom} to ${countryTo}. You'll receive a notification when someone pings remote members for these two countries."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -16,3 +16,5 @@ listing:
 remote:
   remoteMemberRegistered: "${mention} You registered as remote from ${countryFrom} to ${countryTo}. You'll receive a notification when someone pings remote members for these two countries."
   memberDeregisteredFromLocation: "${mention} You deregistered yourself as remote."
+  members: "${mention} These members are registered as remote: ${members}"
+  noMembers: "${mention} There are no members registered as remote." 

--- a/locales/ptbr.yaml
+++ b/locales/ptbr.yaml
@@ -13,3 +13,5 @@ errors:
   failedToFetchContent: "${mention} nao pude buscar o conteudo que voce procura. Tente outro assunto ou topico."
 listing:
   noMembers: "${mention} Não existem pessoas registradas."
+remote:
+  remoteMemberRegistered: "${mention} Você se registrou como remoto do ${countryFom} para ${countryTo}. Você receberá uma notificação sempre que alguém procurar informações sobre esta localização."

--- a/locales/ptbr.yaml
+++ b/locales/ptbr.yaml
@@ -15,3 +15,6 @@ listing:
   noMembers: "${mention} Não existem pessoas registradas."
 remote:
   remoteMemberRegistered: "${mention} Você se registrou como remoto do ${countryFom} para ${countryTo}. Você receberá uma notificação sempre que alguém procurar informações sobre esta localização."
+  memberDeregisteredFromLocation: "${mention} Você se removeu da lista de remotos."
+  members: "${mention} Estas pessoas estão registradas como remoto: ${members}"
+  noMembers: "${mention} Não há pessoas registradas como remoto."

--- a/src/command.ts
+++ b/src/command.ts
@@ -10,6 +10,9 @@ export enum Command {
   PingAdmins = 'ping_admins',
   FindMember = 'find_member',
   Help = 'help',
+  RegisterRemoteMember = 'register_remote_member',
+  FindRemoteMemberTo = 'find_remote_member_to',
+  FindRemoteMemberFrom = 'find_remote_member_from'
 }
 
 enum PortugueseCommandAlias {
@@ -50,6 +53,10 @@ const DefaultCommandDescriptions: Record<Command, string> = {
   [Command.PingAdmins]: 'Ping all admins.',
   [Command.FindMember]: 'Find all locations you are registered to.',
   [Command.Help]: 'Help about various subjects.',
+  [Command.FindRemoteMemberFrom]: 'test',
+  [Command.FindRemoteMemberTo]: 'test',
+  [Command.RegisterRemoteMember]: 'test'
+  
 };
 
 const CommandDescriptionMap: Record<string, string> = {
@@ -138,4 +145,7 @@ export const CommandAliases: Record<Command, string[]> = {
     EnglishCommandAlias.RankCountryMemberCount,
   ],
   [Command.Help]: [Command.Help, PortugueseCommandAlias.Help],
+  [Command.FindRemoteMemberFrom]: [Command.FindRemoteMemberFrom],
+  [Command.FindRemoteMemberTo]: [Command.FindRemoteMemberTo],
+  [Command.RegisterRemoteMember]: [Command.RegisterRemoteMember]
 };

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,7 +14,7 @@ export enum Command {
   DeregisterRemoteMember = 'deregister_remote_member',
   PingRemote = 'ping_remote',
   FindRemoteMemberTo = 'find_remote_member_to',
-  FindRemoteMemberFrom = 'find_remote_member_from'
+  FindRemoteMemberFrom = 'find_remote_member_from',
 }
 
 enum PortugueseCommandAlias {
@@ -25,8 +25,13 @@ enum PortugueseCommandAlias {
   PingMembersAt = 'alo',
   PingAdmins = 'eita',
   DeregisterMemberFrom = 'sair',
+  DeregisterRemoteMember = 'sair_remoto',
   FindMember = 'ondeestou',
   Help = 'ajuda',
+  PingRemote = 'remoto',
+  RegisterRemoteMember = 'estou_remoto',
+  FindRemoteMemberTo = 'quem_remoto_para',
+  FindRemoteMemberFrom = 'quem_remoto_do',
 }
 
 enum EnglishCommandAlias {
@@ -55,12 +60,14 @@ const DefaultCommandDescriptions: Record<Command, string> = {
   [Command.PingAdmins]: 'Ping all admins.',
   [Command.FindMember]: 'Find all locations you are registered to.',
   [Command.Help]: 'Help about various subjects.',
-  [Command.FindRemoteMemberFrom]: 'Find members that are remote from a country',
-  [Command.FindRemoteMemberTo]: 'Find members that are remote to a country',
+  [Command.FindRemoteMemberFrom]:
+    'Find members that are remote from a country',
+  [Command.FindRemoteMemberTo]:
+    'Find members that are remote to a country',
   [Command.RegisterRemoteMember]: 'Register you as a remote member',
-  [Command.DeregisterRemoteMember]: 'Deregister you from the remote members',
-  [Command.PingRemote]: 'Ping remote remembers'
-  
+  [Command.DeregisterRemoteMember]:
+    'Deregister you from the remote members',
+  [Command.PingRemote]: 'Ping remote remembers',
 };
 
 const CommandDescriptionMap: Record<string, string> = {
@@ -98,6 +105,14 @@ const CommandDescriptionMap: Record<string, string> = {
     'Classifica os países baseado no número de pessoas registradas.',
   [PortugueseCommandAlias.Help]:
     'Ajuda sobre assuntos e tópicos diversos.',
+  [PortugueseCommandAlias.DeregisterRemoteMember]:
+    'Remove você da lista de remoto',
+  [PortugueseCommandAlias.FindRemoteMemberFrom]:
+    'Encontra pessoas que estão trabalhando remoto de um país',
+  [PortugueseCommandAlias.FindRemoteMemberTo]:
+    'Encontra pessoas que estão trabalhando remoto para um país',
+  [PortugueseCommandAlias.RegisterRemoteMember]:
+    'Se registra como trabalhando remoto',
 };
 
 export const CommandDescriptions: BotCommand[] = Object.keys(
@@ -149,9 +164,24 @@ export const CommandAliases: Record<Command, string[]> = {
     EnglishCommandAlias.RankCountryMemberCount,
   ],
   [Command.Help]: [Command.Help, PortugueseCommandAlias.Help],
-  [Command.FindRemoteMemberFrom]: [Command.FindRemoteMemberFrom],
-  [Command.FindRemoteMemberTo]: [Command.FindRemoteMemberTo],
-  [Command.RegisterRemoteMember]: [Command.RegisterRemoteMember],
-  [Command.DeregisterRemoteMember]: [Command.DeregisterRemoteMember],
-  [Command.PingRemote]: [Command.PingRemote]
+  [Command.FindRemoteMemberFrom]: [
+    Command.FindRemoteMemberFrom,
+    PortugueseCommandAlias.FindRemoteMemberFrom,
+  ],
+  [Command.FindRemoteMemberTo]: [
+    Command.FindRemoteMemberTo,
+    PortugueseCommandAlias.FindRemoteMemberTo,
+  ],
+  [Command.RegisterRemoteMember]: [
+    Command.RegisterRemoteMember,
+    PortugueseCommandAlias.FindRemoteMemberFrom,
+  ],
+  [Command.DeregisterRemoteMember]: [
+    Command.DeregisterRemoteMember,
+    PortugueseCommandAlias.DeregisterRemoteMember,
+  ],
+  [Command.PingRemote]: [
+    Command.PingRemote,
+    PortugueseCommandAlias.PingRemote,
+  ],
 };

--- a/src/command.ts
+++ b/src/command.ts
@@ -67,7 +67,7 @@ const DefaultCommandDescriptions: Record<Command, string> = {
   [Command.RegisterRemoteMember]: 'Register you as a remote member',
   [Command.DeregisterRemoteMember]:
     'Deregister you from the remote members',
-  [Command.PingRemote]: 'Ping remote remembers',
+  [Command.PingRemote]: 'Ping remote members',
 };
 
 const CommandDescriptionMap: Record<string, string> = {

--- a/src/command.ts
+++ b/src/command.ts
@@ -11,6 +11,8 @@ export enum Command {
   FindMember = 'find_member',
   Help = 'help',
   RegisterRemoteMember = 'register_remote_member',
+  DeregisterRemoteMember = 'deregister_remote_member',
+  PingRemote = 'ping_remote',
   FindRemoteMemberTo = 'find_remote_member_to',
   FindRemoteMemberFrom = 'find_remote_member_from'
 }
@@ -53,9 +55,11 @@ const DefaultCommandDescriptions: Record<Command, string> = {
   [Command.PingAdmins]: 'Ping all admins.',
   [Command.FindMember]: 'Find all locations you are registered to.',
   [Command.Help]: 'Help about various subjects.',
-  [Command.FindRemoteMemberFrom]: 'test',
-  [Command.FindRemoteMemberTo]: 'test',
-  [Command.RegisterRemoteMember]: 'test'
+  [Command.FindRemoteMemberFrom]: 'Find members that are remote from a country',
+  [Command.FindRemoteMemberTo]: 'Find members that are remote to a country',
+  [Command.RegisterRemoteMember]: 'Register you as a remote member',
+  [Command.DeregisterRemoteMember]: 'Deregister you from the remote members',
+  [Command.PingRemote]: 'Ping remote remembers'
   
 };
 
@@ -147,5 +151,7 @@ export const CommandAliases: Record<Command, string[]> = {
   [Command.Help]: [Command.Help, PortugueseCommandAlias.Help],
   [Command.FindRemoteMemberFrom]: [Command.FindRemoteMemberFrom],
   [Command.FindRemoteMemberTo]: [Command.FindRemoteMemberTo],
-  [Command.RegisterRemoteMember]: [Command.RegisterRemoteMember]
+  [Command.RegisterRemoteMember]: [Command.RegisterRemoteMember],
+  [Command.DeregisterRemoteMember]: [Command.DeregisterRemoteMember],
+  [Command.PingRemote]: [Command.PingRemote]
 };

--- a/src/commands/deregisterRemoteMember.ts
+++ b/src/commands/deregisterRemoteMember.ts
@@ -1,0 +1,16 @@
+import { Middleware } from 'telegraf';
+import { BotContext } from '../context';
+
+export const cmdDeregisterRemoteMember: Middleware<BotContext> = async (
+  ctx
+) => {
+  const i18n = ctx.i18n;
+
+  await ctx.database.removeRemoteMember(ctx.safeUser.id);
+
+  return ctx.replyWithAutoDestructiveMessage(
+    i18n.t('remote.memberDeregistered', {
+      mention: ctx.safeUser.mention,
+    })
+  );
+};

--- a/src/commands/pingRemote.ts
+++ b/src/commands/pingRemote.ts
@@ -7,7 +7,7 @@ export const cmdPingRemote: Middleware<BotContext> = async (ctx) => {
   const remoteMembers = await ctx.fetchRemoteMembersMentionList();
 
   const hasNoMembers = remoteMembers.length === 0;
-
+  console.log(remoteMembers)
   const message = hasNoMembers
     ? i18n.t('remote.noMembers', {
         mention: ctx.safeUser.mention,

--- a/src/commands/pingRemote.ts
+++ b/src/commands/pingRemote.ts
@@ -1,0 +1,24 @@
+import { Middleware } from 'telegraf';
+import { BotContext } from '../context';
+
+export const cmdPingRemote: Middleware<BotContext> = async (ctx) => {
+  const i18n = ctx.i18n;
+
+  const remoteMembers = await ctx.fetchRemoteMembersMentionList();
+
+  const hasNoMembers = remoteMembers.length === 0;
+
+  const message = hasNoMembers
+    ? i18n.t('remote.noMembers', {
+        mention: ctx.safeUser.mention,
+      })
+    : i18n.t('remote.members', {
+        mention: ctx.safeUser.mention,
+        members: remoteMembers.join(', '),
+      });
+
+  return ctx.replyWithAutoDestructiveMessage(message, {
+    deleteReplyMessage: hasNoMembers,
+    deleteCommandMessage: hasNoMembers,
+  });
+};

--- a/src/commands/registerMemberAt.ts
+++ b/src/commands/registerMemberAt.ts
@@ -14,6 +14,8 @@ export const cmdRegisterMemberAt: Middleware<BotContext> = async (
     .escape(ctx.command.args ?? '')
     .trim();
 
+  
+
   if (!unsafeCountryName) {
     return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.noCountryProvided', {

--- a/src/commands/registerRemoteMember.ts
+++ b/src/commands/registerRemoteMember.ts
@@ -1,0 +1,80 @@
+import { Middleware } from 'telegraf';
+import { markdown } from 'telegram-format';
+import { BotContext } from '../context';
+import {
+  getCountryCodeForText,
+  getCountryNameForCountryCode,
+} from '../countries';
+
+export const cmdRegisterRemoteMember: Middleware<BotContext> = async (
+  ctx
+) => {
+  const i18n = ctx.i18n;
+  const countries = markdown
+    .escape(ctx.command.args ?? '')
+    .trim()
+    .split(' ');
+
+  if (!countries[0]) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.noCountryProvided', {
+        mention: ctx.safeUser.mention,
+      })
+    );
+  }
+
+  const countryCodeTo = getCountryCodeForText(countries[0]);
+
+  if (!countryCodeTo) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.failedToIdentifyCountry', {
+        mention: ctx.safeUser.mention,
+        countryName: countries[0],
+      })
+    );
+  }
+
+  if (!countries[1]) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.noCountryProvided', {
+        mention: ctx.safeUser.mention,
+      })
+    );
+  }
+
+  const countryCodeFrom = getCountryCodeForText(countries[1]);
+
+  if (!countryCodeFrom) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.failedToIdentifyCountry', {
+        mention: ctx.safeUser.mention,
+        countryName: countries[1],
+      })
+    );
+  }  
+
+  const database = ctx.database;
+  const userId = ctx.safeUser.id;
+
+  if (database.hasRemoteMemberRegistered(userId)) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.memberAlreadyRegistered', {
+        mention: ctx.safeUser.mention,
+      })
+    );
+  }
+
+  await database.addRemoteMember(
+    userId,
+    countryCodeFrom,
+    countryCodeTo
+  );
+
+  return ctx.replyWithAutoDestructiveMessage(
+    i18n.t('remote.remoteMemberRegistered', {
+      mention: ctx.safeUser.mention,
+      countryTo: getCountryNameForCountryCode(countryCodeTo),
+      countryFrom: getCountryNameForCountryCode(countryCodeFrom)
+    })
+  );
+};

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,9 @@ export interface BotContext extends Context {
     countryCode: Alpha2Code,
     silenced?: boolean
   ) => Promise<string[]>;
+  fetchRemoteMembersMentionList: (
+    silenced?: boolean
+  ) => Promise<string[]>;
   replyWithAutoDestructiveMessage: (
     markdownMessage: string,
     options?: AutoDestructiveMessageOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import { createCommandMiddleware } from './middlewares/createCommandMiddleware';
 import { createBlockMiddleware } from './middlewares/createBlockMiddleware';
 import { createLoggerMiddleware } from './middlewares/createLoggerMiddleware';
 import { cmdRegisterRemoteMember } from './commands/registerRemoteMember';
+import { cmdDeregisterRemoteMember } from './commands/deregisterRemoteMember';
+import { cmdPingRemote } from './commands/pingRemote';
 
 const main = async () => {
   const config = await loadConfiguration();
@@ -72,6 +74,11 @@ const main = async () => {
     CommandAliases[Command.RegisterRemoteMember],
     cmdRegisterRemoteMember
   );
+  bot.command(
+    CommandAliases[Command.DeregisterRemoteMember],
+    cmdDeregisterRemoteMember
+  );
+  bot.command(CommandAliases[Command.PingRemote], cmdPingRemote);
 
   process.once('SIGINT', () => bot.stop('SIGINT'));
   process.once('SIGTERM', () => bot.stop('SIGTERM'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { createContextMiddleware } from './middlewares/createContextMiddleware';
 import { createCommandMiddleware } from './middlewares/createCommandMiddleware';
 import { createBlockMiddleware } from './middlewares/createBlockMiddleware';
 import { createLoggerMiddleware } from './middlewares/createLoggerMiddleware';
+import { cmdRegisterRemoteMember } from './commands/registerRemoteMember';
 
 const main = async () => {
   const config = await loadConfiguration();
@@ -66,6 +67,10 @@ const main = async () => {
   bot.command(
     CommandAliases[Command.DeregisterMemberFrom],
     cmdDeregisterMemberFrom
+  );
+  bot.command(
+    CommandAliases[Command.RegisterRemoteMember],
+    cmdRegisterRemoteMember
   );
 
   process.once('SIGINT', () => bot.stop('SIGINT'));

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,0 +1,29 @@
+import { BotContext } from '../context';
+import { getCountryCodeForText } from '../countries';
+
+export const validateCountry = (
+  countryName: string,
+  ctx: BotContext
+) => {
+  const i18n = ctx.i18n;
+  if (!countryName) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.noCountryProvided', {
+        mention: ctx.safeUser.mention,
+      })
+    );
+  }
+
+  const countryCode = getCountryCodeForText(countryName);
+
+  if (!countryCode) {
+    return ctx.replyWithAutoDestructiveMessage(
+      i18n.t('errors.failedToIdentifyCountry', {
+        mention: ctx.safeUser.mention,
+        countryName: countryName,
+      })
+    );
+  }
+
+  return countryCode;
+};

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,29 +1,36 @@
+import { Alpha2Code } from 'i18n-iso-countries';
 import { BotContext } from '../context';
 import { getCountryCodeForText } from '../countries';
+
+interface CountryValidation {
+  countryCode: Alpha2Code | null;
+  error: string | null;
+}
 
 export const validateCountry = (
   countryName: string,
   ctx: BotContext
-) => {
+): CountryValidation => {
   const i18n = ctx.i18n;
   if (!countryName) {
-    return ctx.replyWithAutoDestructiveMessage(
-      i18n.t('errors.noCountryProvided', {
-        mention: ctx.safeUser.mention,
-      })
-    );
+    const errorMessage = i18n.t('errors.noCountryProvided', {
+      mention: ctx.safeUser.mention,
+    });
+    return { countryCode: null, error: errorMessage };
   }
 
   const countryCode = getCountryCodeForText(countryName);
 
   if (!countryCode) {
-    return ctx.replyWithAutoDestructiveMessage(
-      i18n.t('errors.failedToIdentifyCountry', {
-        mention: ctx.safeUser.mention,
-        countryName: countryName,
-      })
-    );
+    const errorMessage = i18n.t('errors.failedToIdentifyCountry', {
+      mention: ctx.safeUser.mention,
+      countryName: countryName,
+    });
+    return {
+      countryCode: null,
+      error: errorMessage,
+    };
   }
 
-  return countryCode;
+  return { countryCode: countryCode, error: null };
 };


### PR DESCRIPTION
Hey ! 

I've added the support to having members register as remote workers it work as following:

`/register_remote_member [country_from] [country_to]` And it will register a new user that's working remotely from one country to another, or even to the same country.

`/deregister_remote_member` removes a user from the remote workers list

`/ping_remote` pings all remote users

`/find_remote_member_from [country_code]` finds remote workers from a certain country

`/find_remote_country_to [country_code]`  finds remote workers working to a certain country

The last two commands are still to be done, and i hope to finish them tomorrow.

Let me know what you think !